### PR TITLE
Add trailing_slash=false to all the get_url invocations for assets.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -10,13 +10,13 @@
       <title>{% block title %}{{ config.title }}{% endblock title %}</title>
 
       <!-- CSS -->
-      <link rel="stylesheet" href="{{ get_url(path="print.css") }}" media="print">
-      <link rel="stylesheet" href="{{ get_url(path="poole.css") }}">
-      <link rel="stylesheet" href="{{ get_url(path="hyde.css") }}">
+      <link rel="stylesheet" href="{{ get_url(path="print.css", trailing_slash=false) }}" media="print">
+      <link rel="stylesheet" href="{{ get_url(path="poole.css", trailing_slash=false) }}">
+      <link rel="stylesheet" href="{{ get_url(path="hyde.css", trailing_slash=false) }}">
       <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
 
       {% if config.generate_rss %}
-        <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ get_url(path="rss.xml") }}">
+        <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ get_url(path="rss.xml", trailing_slash=false) }}">
       {% endif %}
 
       {% block extra_head %}


### PR DESCRIPTION
I was getting links to `https://example.org/print.css/` and similar, which return 404 from at least github pages.