### PR TITLE
Use https to avoid mixed content.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -13,7 +13,7 @@
       <link rel="stylesheet" href="{{ get_url(path="print.css", trailing_slash=false) }}" media="print">
       <link rel="stylesheet" href="{{ get_url(path="poole.css", trailing_slash=false) }}">
       <link rel="stylesheet" href="{{ get_url(path="hyde.css", trailing_slash=false) }}">
-      <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
+      <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
 
       {% if config.generate_rss %}
         <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ get_url(path="rss.xml", trailing_slash=false) }}">


### PR DESCRIPTION
Getting google fonts via http causes mixed content error like below.
```
Mixed Content: The page at 'https://bon-chi.github.io/blog/' was loaded over HTTPS, 
but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface'. 
This request has been blocked; the content must be served over HTTPS.
```