### PR TITLE
Enable horizontal scrolling in pre elements

### DIFF
--- a/sass/poole.scss
+++ b/sass/poole.scss
@@ -163,10 +163,7 @@ pre {
   padding: 1rem;
   font-size: .8rem;
   line-height: 1.4;
-  white-space: pre;
-  white-space: pre-wrap;
-  word-break: break-all;
-  word-wrap: break-word;
+  overflow-x: scroll;
   background-color: #f9f9f9;
 }
 pre code {


### PR DESCRIPTION
The default content width is rather narrow, which is reasonable for text, but tends to wrap the code blocks.

Before:
![image](https://user-images.githubusercontent.com/308347/43689393-3af4f756-98fa-11e8-9b2f-1378dcc85477.png)

After:
![image](https://user-images.githubusercontent.com/308347/43689386-19ea0c68-98fa-11e8-8ec9-0b94c00adc6b.png)
